### PR TITLE
Implemented OSX UVC property controls (Experimental)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,8 @@ ELSEIF(APPLE)
                 common/logging.cpp
                 common/stream.cpp
                 mac/platformcontext.mm
-                mac/platformstream.mm)
+                mac/platformstream.mm
+                mac/uvcctrl.mm)
 
 
     # create the library
@@ -91,6 +92,7 @@ ELSEIF(APPLE)
         "-framework CoreMedia"
         "-framework CoreVideo"
         "-framework Accelerate"
+        "-framework IOKit"
         )
 
     # add mac specific test application

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ OpenPnP Capture is a cross platform video capture library with a focus on machin
 | Capturing | Yes |
 | MJPEG formats | Yes (dmb1) |
 | YUV formats | Yes |
-| Exposure control | No |
-| Focus control | No |
-| Zoom control | No |
-| Gain control | No |
-| White balance control | No |
+| Exposure control | Yes / Experimental |
+| Focus control | Yes / Experimental |
+| Zoom control | Yes / Experimental |
+| Gain control | Yes / Experimental |
+| White balance control | Yes / Experimental |
 | Framerate control | No |
 
 # Building OpenPnP Capture

--- a/mac/QtCaptureTest/mainwindow.h
+++ b/mac/QtCaptureTest/mainwindow.h
@@ -29,8 +29,10 @@ public slots:
 
     void onAutoExposure(bool state);
     void onAutoWhiteBalance(bool state);
+    void onAutoGain(bool state);
     void onExposureSlider(int value);
     void onWhiteBalanceSlider(int value);
+    void onGainSlider(int value);
 
 private:
     CapFormatInfo           m_finfo;
@@ -39,8 +41,10 @@ private:
 
     QCheckBox*  m_autoWhiteBalance;
     QCheckBox*  m_autoExposure;
+    QCheckBox*  m_autoGain;
     QSlider*    m_exposureSlider;
     QSlider*    m_whiteBalanceSlider;
+    QSlider*    m_gainSlider;
 
 
     QTimer*     m_refreshTimer;

--- a/mac/QtCaptureTest/mainwindow.h
+++ b/mac/QtCaptureTest/mainwindow.h
@@ -4,6 +4,8 @@
 #include <QMainWindow>
 #include <QTimer>
 #include <QLabel>
+#include <QCheckBox>
+#include <QSlider>
 #include <vector>
 #include "openpnp-capture.h"
 
@@ -19,14 +21,27 @@ public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
 
+    void readCameraSettings();
+
 public slots:
     void doFrameUpdate();
     void changeCamera(int index);
+
+    void onAutoExposure(bool state);
+    void onAutoWhiteBalance(bool state);
+    void onExposureSlider(int value);
+    void onWhiteBalanceSlider(int value);
 
 private:
     CapFormatInfo           m_finfo;
     std::vector<uint8_t>    m_frameData;
     QLabel*     m_frameDisplay;
+
+    QCheckBox*  m_autoWhiteBalance;
+    QCheckBox*  m_autoExposure;
+    QSlider*    m_exposureSlider;
+    QSlider*    m_whiteBalanceSlider;
+
 
     QTimer*     m_refreshTimer;
     CapContext  m_ctx;

--- a/mac/platformcontext.mm
+++ b/mac/platformcontext.mm
@@ -42,10 +42,14 @@ bool PlatformContext::enumerateDevices()
 
         // extract the PID/VID from the model name
         NSRange vidRange = [device.modelID rangeOfString:@"VendorID_"];
-        deviceInfo->m_vid = [[device.modelID substringWithRange:NSMakeRange(vidRange.location + 9, 5)] intValue];
+        uint32_t maxLen = device.modelID.length - vidRange.location - 9;
+        maxLen = (maxLen > 5) ? 5 : maxLen;        
+        deviceInfo->m_vid = [[device.modelID substringWithRange:NSMakeRange(vidRange.location + 9, maxLen)] intValue];
 
         NSRange pidRange = [device.modelID rangeOfString:@"ProductID_"];
-        deviceInfo->m_pid = [[device.modelID substringWithRange:NSMakeRange(pidRange.location + 10, 5)] intValue];
+        maxLen = device.modelID.length - pidRange.location - 10;
+        maxLen = (maxLen > 5) ? 5 : maxLen;
+        deviceInfo->m_pid = [[device.modelID substringWithRange:NSMakeRange(pidRange.location + 10, maxLen)] intValue];
 
         LOG(LOG_DEBUG, "USB  : vid=%04X  pid=%04X\n", deviceInfo->m_vid, deviceInfo->m_pid);
  

--- a/mac/platformcontext.mm
+++ b/mac/platformcontext.mm
@@ -32,13 +32,23 @@ bool PlatformContext::enumerateDevices()
     {
         platformDeviceInfo* deviceInfo = new platformDeviceInfo();
         deviceInfo->m_captureDevice = CFBridgingRetain(device);
-        
         deviceInfo->m_name = std::string(device.localizedName.UTF8String) + " (" + std::string(device.manufacturer.UTF8String) + ")";
         deviceInfo->m_uniqueID = deviceInfo->m_name  + " " + std::string(device.uniqueID.UTF8String);
-        
-        LOG(LOG_DEBUG, "Name: %s\n", deviceInfo->m_name.c_str());
-        LOG(LOG_DEBUG, "ID  : %s\n", deviceInfo->m_uniqueID.c_str());
 
+        std::string model = device.modelID.UTF8String;
+        LOG(LOG_DEBUG, "Name : %s\n", deviceInfo->m_name.c_str());
+        LOG(LOG_DEBUG, "Model: %s\n", model.c_str());
+        LOG(LOG_DEBUG, "ID   : %s\n", deviceInfo->m_uniqueID.c_str());
+
+        // extract the PID/VID from the model name
+        NSRange vidRange = [device.modelID rangeOfString:@"VendorID_"];
+        deviceInfo->m_vid = [[device.modelID substringWithRange:NSMakeRange(vidRange.location + 9, 5)] intValue];
+
+        NSRange pidRange = [device.modelID rangeOfString:@"ProductID_"];
+        deviceInfo->m_pid = [[device.modelID substringWithRange:NSMakeRange(pidRange.location + 10, 5)] intValue];
+
+        LOG(LOG_DEBUG, "USB  : vid=%04X  pid=%04X\n", deviceInfo->m_vid, deviceInfo->m_pid);
+ 
         for (AVCaptureDeviceFormat* format in device.formats) 
         {
             //Do we really need a complete list of frame rates?

--- a/mac/platformdeviceinfo.h
+++ b/mac/platformdeviceinfo.h
@@ -1,3 +1,14 @@
+/*
+
+    OpenPnp-Capture: a video capture subsystem.
+
+    OSX platform device info object
+
+    Created by Niels Moseley on 7/6/17.
+    Copyright © 2017 Niels Moseley, Jason von Nieda.
+
+*/
+
 #ifndef platformdeviceinfo_h
 #define platformdeviceinfo_h
 
@@ -15,6 +26,8 @@ public:
     platformDeviceInfo() : deviceInfo() 
     {
         m_captureDevice = nullptr;
+        m_pid = 0;
+        m_vid = 0;
     }
 
     virtual ~platformDeviceInfo()
@@ -37,6 +50,11 @@ public:
 
     CFTypeRef m_captureDevice;   ///< pointer to AVCaptureDevice
     std::vector<AVCaptureDeviceFormat*> m_platformFormats; ///< formats supported by the device
+
+    // save USB PID/VID so we can access the UVC camera
+    // directly for setting focus/exposure etc.
+    uint16_t m_pid; // USB product ID (if found) 
+    uint16_t m_vid; // USB vendor ID (if found)
 };
 
 #endif

--- a/mac/platformstream.h
+++ b/mac/platformstream.h
@@ -2,10 +2,10 @@
 
     OpenPnp-Capture: a video capture subsystem.
 
-    Windows platform code
+    OSX platform code
 
     Created by Niels Moseley on 7/6/17.
-    Copyright © 2017 Niels Moseley. All rights reserved.
+    Copyright © 2017 Niels Moseley, Jason von Nieda.
 
     Stream class
 
@@ -17,10 +17,13 @@
 #include <stdint.h>
 #include "../common/logging.h"
 #include "../common/stream.h"
+
 #import <AVFoundation/AVFoundation.h>
 #import <CoreFoundation/CoreFoundation.h>
 #import <CoreMedia/CoreMedia.h>
 #import <CoreVideo/CoreVideo.h>
+
+#include "uvcctrl.h"
 
 class Context;          // pre-declaration
 class PlatformStream;  // pre-declaration
@@ -84,7 +87,9 @@ protected:
     AVCaptureDevice*    m_device;       ///< note: we do not own the objecgt itself!
     dispatch_queue_t    m_queue;
 
-    std::vector<uint8_t> m_tmpBuffer;  ///< intermediate buffer for 32->24 bit conversion
+    std::vector<uint8_t> m_tmpBuffer;   ///< intermediate buffer for 32->24 bit conversion
+
+    UVCCtrl             *m_uvc;         ///< UVC USB control object, can be NULL!
 
     /** generate FOURCC string from a uint32 */
     std::string genFOURCCstring(uint32_t v);

--- a/mac/tests/main.cpp
+++ b/mac/tests/main.cpp
@@ -193,6 +193,16 @@ int main(int argc, char*argv[])
         printf("Failed to get exposure!\n");
     }
 
+    uint32_t vvv;
+    if (Cap_getAutoProperty(ctx, streamID, CAPPROPID_EXPOSURE, &vvv))
+    {
+        printf("Auto exposure: %d\n", vvv);
+    }
+    else
+    {
+        printf("Failed to get auto exposure!\n");
+    }
+
     //disable auto exposure, focus and white balance
     //Cap_setAutoProperty(ctx, streamID, CAPPROPID_EXPOSURE, 0);
     //Cap_setAutoProperty(ctx, streamID, CAPPROPID_FOCUS, 0);

--- a/mac/tests/main.cpp
+++ b/mac/tests/main.cpp
@@ -12,6 +12,7 @@
 
 #include "openpnp-capture.h"
 #include "../common/context.h"
+#include "../uvcctrl.h"
 
 bool writeBufferAsPPM(uint32_t frameNum, uint32_t width, uint32_t height, const uint8_t *bufferPtr, size_t bytes)
 {
@@ -41,7 +42,7 @@ int main(int argc, char*argv[])
     printf(" OpenPNP Capture Test Program\n");
     printf(" %s\n", Cap_getLibraryVersion());
     printf("==============================\n");
-    Cap_setLogLevel(7);
+    Cap_setLogLevel(8);
 
     if (argc == 1)
     {
@@ -116,8 +117,48 @@ int main(int argc, char*argv[])
     CapFormatInfo finfo;
     Cap_getFormatInfo(ctx, deviceID, deviceFormatID, &finfo);
 
-    // try to open the first camera device found
-    //DLLPUBLIC CapStream Cap_openStream(CapContext ctx, CapDeviceID index, CapFormatID formatID);
+
+    UVCCtrl *ctrl = UVCCtrl::create(0x05AC, 0x8502);
+    if (ctrl != nullptr)
+    {
+        printf("Created UVC control interface!\n");
+
+        bool state;
+        if (ctrl->getAutoProperty(CAPPROPID_EXPOSURE, state))
+        {
+            printf("Auto white balance is: %s\n", state ? "ON" : " OFF");
+        }
+        else
+        {
+            printf("Cannot get white balance state..\n");
+        }
+        
+        int32_t value, emin, emax;
+        if (ctrl->getProperty(CAPPROPID_EXPOSURE, &value))
+        {
+            printf("Exposure is: %d\n", value);
+        }
+        else
+        {
+            printf("Cannot get exposure..\n");
+        }
+
+        if (ctrl->getPropertyLimits(CAPPROPID_EXPOSURE, &emin, &emax))
+        {
+            printf("Exposure limits are: %d .. %d\n", emin, emax);
+        }
+        else
+        {
+            printf("Cannot get exposure limits..\n");
+        }
+
+        delete ctrl;
+    }
+    else
+    {
+        printf("Failed to create UVC control interface\n");
+    }
+
     
     int32_t streamID = Cap_openStream(ctx, deviceID, deviceFormatID);
     printf("Stream ID = %d\n", streamID);
@@ -133,10 +174,10 @@ int main(int argc, char*argv[])
     }
 
     //disable auto exposure, focus and white balance
-    Cap_setAutoProperty(ctx, streamID, CAPPROPID_EXPOSURE, 0);
-    Cap_setAutoProperty(ctx, streamID, CAPPROPID_FOCUS, 0);
-    Cap_setAutoProperty(ctx, streamID, CAPPROPID_WHITEBALANCE, 0);
-    Cap_setAutoProperty(ctx, streamID, CAPPROPID_GAIN, 0);
+    //Cap_setAutoProperty(ctx, streamID, CAPPROPID_EXPOSURE, 0);
+    //Cap_setAutoProperty(ctx, streamID, CAPPROPID_FOCUS, 0);
+    //Cap_setAutoProperty(ctx, streamID, CAPPROPID_WHITEBALANCE, 0);
+    //Cap_setAutoProperty(ctx, streamID, CAPPROPID_GAIN, 0);
 
     std::vector<uint8_t> m_buffer;
     m_buffer.resize(finfo.width*finfo.height*3);

--- a/mac/tests/main.cpp
+++ b/mac/tests/main.cpp
@@ -118,13 +118,14 @@ int main(int argc, char*argv[])
     Cap_getFormatInfo(ctx, deviceID, deviceFormatID, &finfo);
 
 
+    #if 0
     UVCCtrl *ctrl = UVCCtrl::create(0x05AC, 0x8502);
     if (ctrl != nullptr)
     {
         printf("Created UVC control interface!\n");
 
         bool state;
-        if (ctrl->getAutoProperty(CAPPROPID_EXPOSURE, state))
+        if (ctrl->getAutoProperty(CAPPROPID_WHITEBALANCE, state))
         {
             printf("Auto white balance is: %s\n", state ? "ON" : " OFF");
         }
@@ -158,7 +159,7 @@ int main(int argc, char*argv[])
     {
         printf("Failed to create UVC control interface\n");
     }
-
+    #endif
     
     int32_t streamID = Cap_openStream(ctx, deviceID, deviceFormatID);
     printf("Stream ID = %d\n", streamID);
@@ -171,6 +172,25 @@ int main(int argc, char*argv[])
     {
         printf("Stream is closed (?)\n");
         return 1;
+    }
+
+    int32_t emin,emax;
+    if (Cap_getPropertyLimits(ctx, streamID, CAPPROPID_EXPOSURE, &emin, &emax))
+    {
+        printf("Exposure limits: %d .. %d\n", emin, emax);
+    }
+    else
+    {
+        printf("Failed to get exposure limits!\n");
+    }
+
+    if (Cap_getProperty(ctx, streamID, CAPPROPID_EXPOSURE, &emin))
+    {
+        printf("Exposure: %d\n", emin);
+    }
+    else
+    {
+        printf("Failed to get exposure!\n");
     }
 
     //disable auto exposure, focus and white balance

--- a/mac/uvcctrl.h
+++ b/mac/uvcctrl.h
@@ -52,6 +52,7 @@ protected:
 
     static IOUSBInterfaceInterface190** findDevice(uint16_t vid, uint16_t pid);
     static IOUSBInterfaceInterface190** createControlInterface(IOUSBDeviceInterface** deviceInterface);
+    static uint32_t getProcessingUnitID(IOUSBDeviceInterface**);
 
     bool sendControlRequest(IOUSBDevRequest req);
     bool setData(uint32_t selector, uint32_t unit, uint32_t length, int32_t data);

--- a/mac/uvcctrl.h
+++ b/mac/uvcctrl.h
@@ -1,0 +1,68 @@
+/*
+
+    OpenPnp-Capture: a video capture subsystem.
+
+    OSX platform code
+
+    Created by Niels Moseley on 7/6/17.
+    Copyright © 2017 Niels Moseley, Jason von Nieda.
+
+    UVC camera controls
+
+*/
+
+#ifndef uvcctrl_h
+#define uvcctrl_h
+
+#import <CoreFoundation/CoreFoundation.h>
+
+#include <IOKit/IOKitLib.h>
+#include <IOKit/IOCFPlugIn.h>
+#include <IOKit/usb/IOUSBLib.h>
+
+#include "../include/openpnp-capture.h"
+
+class UVCCtrl
+{
+public:
+    virtual ~UVCCtrl();
+
+    /** create a UVC controller for a USB camera */
+    static UVCCtrl* create(uint16_t vid, uint16_t pid)
+    {
+        IOUSBInterfaceInterface190** iface = findDevice(vid, pid);
+        if (iface == nullptr)
+        {
+            return nullptr;
+        }
+        else
+        {
+            return new UVCCtrl(iface);
+        }
+    }
+
+    bool setProperty(uint32_t propID, int32_t value);
+    bool getProperty(uint32_t propID, int32_t *value);
+    bool setAutoProperty(uint32_t propID, bool enabled);
+    bool getAutoProperty(uint32_t propID, bool &enabled);
+    bool getPropertyLimits(uint32_t propID, int32_t *emin, int32_t *emax);
+
+protected:
+    UVCCtrl(IOUSBInterfaceInterface190 **controller)
+        : m_controller(controller)
+    {
+    }
+
+    static IOUSBInterfaceInterface190** findDevice(uint16_t vid, uint16_t pid);
+    static IOUSBInterfaceInterface190** createControlInterface(IOUSBDeviceInterface** deviceInterface);
+
+    bool sendControlRequest(IOUSBDevRequest req);
+    bool setData(uint32_t selector, uint32_t unit, uint32_t length, int32_t data);
+    bool getData(uint32_t selector, uint32_t unit, uint32_t length, int32_t *data);
+    bool getMaxData(uint32_t selector, uint32_t unit, uint32_t length, int32_t *data);
+    bool getMinData(uint32_t selector, uint32_t unit, uint32_t length, int32_t *data);
+
+    IOUSBInterfaceInterface190** m_controller;
+};
+
+#endif

--- a/mac/uvcctrl.h
+++ b/mac/uvcctrl.h
@@ -48,10 +48,7 @@ public:
     bool getPropertyLimits(uint32_t propID, int32_t *emin, int32_t *emax);
 
 protected:
-    UVCCtrl(IOUSBInterfaceInterface190 **controller)
-        : m_controller(controller)
-    {
-    }
+    UVCCtrl(IOUSBInterfaceInterface190 **controller);
 
     static IOUSBInterfaceInterface190** findDevice(uint16_t vid, uint16_t pid);
     static IOUSBInterfaceInterface190** createControlInterface(IOUSBDeviceInterface** deviceInterface);
@@ -62,6 +59,8 @@ protected:
     bool getMaxData(uint32_t selector, uint32_t unit, uint32_t length, int32_t *data);
     bool getMinData(uint32_t selector, uint32_t unit, uint32_t length, int32_t *data);
     bool getInfo(uint32_t selector, uint32_t unit, uint32_t *data);
+
+    void reportCapabilities(uint32_t selector, uint32_t unit);
 
     IOUSBInterfaceInterface190** m_controller;
 };

--- a/mac/uvcctrl.h
+++ b/mac/uvcctrl.h
@@ -44,7 +44,7 @@ public:
     bool setProperty(uint32_t propID, int32_t value);
     bool getProperty(uint32_t propID, int32_t *value);
     bool setAutoProperty(uint32_t propID, bool enabled);
-    bool getAutoProperty(uint32_t propID, bool &enabled);
+    bool getAutoProperty(uint32_t propID, bool *enabled);
     bool getPropertyLimits(uint32_t propID, int32_t *emin, int32_t *emax);
 
 protected:
@@ -61,6 +61,7 @@ protected:
     bool getData(uint32_t selector, uint32_t unit, uint32_t length, int32_t *data);
     bool getMaxData(uint32_t selector, uint32_t unit, uint32_t length, int32_t *data);
     bool getMinData(uint32_t selector, uint32_t unit, uint32_t length, int32_t *data);
+    bool getInfo(uint32_t selector, uint32_t unit, uint32_t *data);
 
     IOUSBInterfaceInterface190** m_controller;
 };

--- a/mac/uvcctrl.mm
+++ b/mac/uvcctrl.mm
@@ -1,0 +1,451 @@
+/*
+
+    OpenPnp-Capture: a video capture subsystem.
+
+    OSX platform code
+
+    Created by Niels Moseley on 7/6/17.
+    Copyright © 2017 Niels Moseley, Jason von Nieda.
+
+    UVC camera controls
+
+*/
+
+#include "uvcctrl.h"
+#include "../common/logging.h"
+
+//
+// constants defined in the UVC USB specfication
+// which you can get here: http://www.usb.org/developers/docs/devclass_docs/USB_Video_Class_1_5.zip
+// 
+
+#define UVC_INPUT_TERMINAL_ID 0x01
+#define UVC_PROCESSING_UNIT_ID 0x02
+
+#define CT_AE_MODE_CONTROL 0x02
+#define CT_AE_PRIORITY_CONTROL 0x03
+#define CT_EXPOSURE_TIME_ABSOLUTE_CONTROL 0x04
+#define CT_EXPOSURE_TIME_RELATEIVE_CONTROL 0x05
+#define CT_FOCUS_ABSOLUTE_CONTROL 0x06
+#define CT_FOCUS_RELATIVE_CONTROL 0x07
+#define CT_FOCUS_AUTO_CONTROL 0x08
+#define CT_ZOOM_ABSOLUTE_CONTROL 0x0B
+#define CT_ZOOM_RELATIVE_CONTROL 0x0C
+
+#define PU_BRIGHTNESS_CONTROL 0x02
+#define PU_CONTRAST_CONTROL 0x03
+#define PU_GAIN_CONTROL 0x04
+#define PU_WHITE_BALANCE_TEMPERATURE_CONTROL 0x0A
+#define PU_WHITE_BALANCE_TEMPERATURE_AUTO_CONTROL 0x0B
+
+#define UVC_CONTROL_INTERFACE_CLASS 14
+#define UVC_CONTROL_INTERFACE_SUBCLASS 1
+
+#define UVC_SET_CUR	0x01
+#define UVC_GET_CUR	0x81
+#define UVC_GET_MIN	0x82
+#define UVC_GET_MAX	0x83
+
+
+UVCCtrl::~UVCCtrl()
+{
+    if (m_controller != nullptr)
+    {
+        (*m_controller)->USBInterfaceClose(m_controller);
+        (*m_controller)->Release(m_controller);
+    }
+}
+
+IOUSBInterfaceInterface190** UVCCtrl::findDevice(uint16_t vid, uint16_t pid)
+{
+    LOG(LOG_DEBUG, "UVCCtrl::findDevice() called\n");
+
+    CFMutableDictionaryRef dict = IOServiceMatching(kIOUSBDeviceClassName);
+
+    io_iterator_t serviceIterator;
+    IOServiceGetMatchingServices(kIOMasterPortDefault, dict, &serviceIterator);
+
+    io_service_t device;
+    while((device = IOIteratorNext(serviceIterator)) != 0)
+    {
+        IOUSBDeviceInterface **deviceInterface = nullptr;
+        IOCFPlugInInterface  **plugInInterface = nullptr;
+        SInt32 score;
+
+        kern_return_t result = IOCreatePlugInInterfaceForService(
+            device, kIOUSBDeviceUserClientTypeID,
+            kIOCFPlugInInterfaceID, &plugInInterface, &score);
+
+        if ((result != kIOReturnSuccess) || (plugInInterface == nullptr))
+        {
+            LOG(LOG_DEBUG, "UVCCtrl::findDevice() Camera control error %d\n", result);
+            //FIXME: log error?
+            continue;
+        }
+        else
+        {
+            HRESULT hr = (*plugInInterface)->QueryInterface(plugInInterface,
+                CFUUIDGetUUIDBytes(kIOUSBDeviceInterfaceID),
+                (LPVOID*)&deviceInterface);
+
+
+            if (hr || (deviceInterface == nullptr))
+            {
+                (*plugInInterface)->Release(plugInInterface);
+                //FIXME: log
+                continue;
+            }
+
+            uint16_t vendorID, productID;
+            result = (*deviceInterface)->GetDeviceVendor(deviceInterface, &vendorID);
+            result = (*deviceInterface)->GetDeviceProduct(deviceInterface, &productID);
+            //LOG(LOG_INFO, "UVC vid=%08X pid=%08X\n", vendorID, productID);
+            if ((vendorID == vid) && (productID == pid))
+            {
+                #if 0
+                IOUSBInterfaceInterface190 **controlInterface;
+
+                hr = (*plugInInterface)->QueryInterface(plugInInterface, 
+                    CFUUIDGetUUIDBytes(kIOUSBInterfaceInterfaceID), (LPVOID *)&controlInterface);
+
+                if (hr || (controlInterface == nullptr))
+                {
+                    LOG(LOG_INFO, "Failed to create UVC control interface (hr=%08X)!\n", hr);
+                }
+                else
+                {
+                    LOG(LOG_INFO, "Created UVC control interface!\n");
+                    (*controlInterface)->Release(controlInterface); 
+                }
+                #endif
+
+                return createControlInterface(deviceInterface);
+            }
+
+            (*plugInInterface)->Release(plugInInterface);
+        }
+    }
+
+    return NULL;
+}
+
+
+IOUSBInterfaceInterface190** UVCCtrl::createControlInterface(IOUSBDeviceInterface** deviceInterface)
+{
+    IOUSBInterfaceInterface190 **controlInterface;
+
+    io_iterator_t interfaceIterator;
+    IOUSBFindInterfaceRequest interfaceRequest;
+    interfaceRequest.bInterfaceClass = UVC_CONTROL_INTERFACE_CLASS;
+    interfaceRequest.bInterfaceSubClass = UVC_CONTROL_INTERFACE_SUBCLASS;
+    interfaceRequest.bInterfaceProtocol = kIOUSBFindInterfaceDontCare;
+    interfaceRequest.bAlternateSetting  = kIOUSBFindInterfaceDontCare;
+
+    IOReturn result = (*deviceInterface)->CreateInterfaceIterator(deviceInterface,
+        &interfaceRequest, &interfaceIterator);
+
+    if (result != kIOReturnSuccess)
+    {
+        return NULL;
+    }
+
+    io_service_t usbInterface;
+    HRESULT hr;
+
+    if ((usbInterface = IOIteratorNext(interfaceIterator)) != 0)
+    {
+        IOCFPlugInInterface **plugInInterface = NULL;
+        SInt32 score;
+        kern_return_t kr = IOCreatePlugInInterfaceForService(usbInterface,
+            kIOUSBInterfaceUserClientTypeID, 
+            kIOCFPlugInInterfaceID, 
+            &plugInInterface,
+            &score);
+
+        kr = IOObjectRelease(usbInterface);
+        if ((kr != kIOReturnSuccess) || !plugInInterface)
+        {
+            LOG(LOG_ERR, "UVCCtrl::createControlInterface cannot create plug-in %08X\n",
+                kr);
+            return NULL;
+        }
+
+        hr = (*plugInInterface)->QueryInterface(plugInInterface,
+            CFUUIDGetUUIDBytes(kIOUSBInterfaceInterfaceID),
+            (LPVOID*) &controlInterface);
+
+        (*plugInInterface)->Release(plugInInterface);
+
+        if (hr || !controlInterface)
+        {
+            LOG(LOG_ERR,"UVCCtrl::createControlInterface: cannot create device interface %08X\n",
+                result);
+                return NULL;
+        }
+        LOG(LOG_DEBUG, "UVCCtrl::createControlInterface: created control interface\n");
+        return controlInterface;
+    }
+    return NULL;
+}
+
+bool UVCCtrl::sendControlRequest(IOUSBDevRequest req)
+{
+    if (m_controller == nullptr)
+    {
+        LOG(LOG_ERR,"UVCCtrl::sendControlRequest: control interface is NULL\n");
+        return false;
+    }
+
+    kern_return_t kr = (*m_controller)->USBInterfaceOpen(m_controller);
+    if (kr != kIOReturnSuccess)
+    {
+        LOG(LOG_ERR, "sendControlRequest USBInterfaceOpen failed!\n");
+        return false;
+    }
+
+    kr = (*m_controller)->ControlRequest(m_controller, 0, &req);
+    if (kr != kIOReturnSuccess)
+    {
+        LOG(LOG_ERR, "sendControlRequest ControlRequest failed!\n");
+        kr = (*m_controller)->USBInterfaceClose(m_controller);
+        return false;
+    }
+
+    //if (req.bRequest != UVC_SET_CUR)
+    //{
+    //    LOG(LOG_VERBOSE, "-> %08X\n", *((int32_t*)req.pData));
+    //}
+
+    kr = (*m_controller)->USBInterfaceClose(m_controller);
+    return true;
+}
+
+bool UVCCtrl::setData(uint32_t selector, uint32_t unit, uint32_t length, int32_t data)
+{
+    IOUSBDevRequest req;
+    req.bmRequestType = USBmakebmRequestType(kUSBOut, kUSBClass, kUSBInterface);
+    req.bRequest = UVC_SET_CUR;
+    req.wValue   = (selector << 8);
+    req.wIndex   = (unit << 8);
+    req.wLength  = length;
+    req.wLenDone = 0;
+    req.pData = &data;
+    return sendControlRequest(req);
+}
+
+bool UVCCtrl::getData(uint32_t selector, uint32_t unit, uint32_t length, int32_t *data)
+{
+    IOUSBDevRequest req;
+    req.bmRequestType = USBmakebmRequestType(kUSBOut, kUSBClass, kUSBInterface);
+    req.bRequest = UVC_GET_CUR;
+    req.wValue   = (selector << 8);
+    req.wIndex   = (unit << 8);
+    req.wLength  = length;
+    req.wLenDone = 0;
+    req.pData = data;
+    return sendControlRequest(req);
+}
+
+bool UVCCtrl::getMaxData(uint32_t selector, uint32_t unit, uint32_t length, int32_t *data)
+{
+    IOUSBDevRequest req;
+    *data = 0;
+    req.bmRequestType = USBmakebmRequestType(kUSBOut, kUSBClass, kUSBInterface);
+    req.bRequest = UVC_GET_MAX;
+    req.wValue   = (selector << 8);
+    req.wIndex   = (unit << 8);
+    req.wLength  = length;
+    req.wLenDone = 0;
+    req.pData = data;
+    return sendControlRequest(req);
+}
+
+bool UVCCtrl::getMinData(uint32_t selector, uint32_t unit, uint32_t length, int32_t *data)
+{
+    IOUSBDevRequest req;
+    *data = 0;
+    req.bmRequestType = USBmakebmRequestType(kUSBOut, kUSBClass, kUSBInterface);
+    req.bRequest = UVC_GET_MIN;
+    req.wValue   = (selector << 8);
+    req.wIndex   = (unit << 8);
+    req.wLength  = length;
+    req.wLenDone = 0;
+    req.pData = data;
+    return sendControlRequest(req);
+}
+
+bool UVCCtrl::setProperty(uint32_t propID, int32_t value)
+{
+    if (m_controller == nullptr)
+    {
+        return false;
+    }
+
+    switch(propID)
+    {
+    case CAPPROPID_EXPOSURE:
+        return setData(CT_EXPOSURE_TIME_ABSOLUTE_CONTROL, UVC_INPUT_TERMINAL_ID, 4, value);
+    case CAPPROPID_FOCUS:
+        return false; // FIXME: not supported yet
+    case CAPPROPID_ZOOM:
+        return false; // FIXME: not supported yet
+    case CAPPROPID_WHITEBALANCE:
+        return setData(PU_WHITE_BALANCE_TEMPERATURE_CONTROL, UVC_PROCESSING_UNIT_ID, 2, value);
+    case CAPPROPID_GAIN:
+        return setData(PU_GAIN_CONTROL, UVC_PROCESSING_UNIT_ID, 2, value);
+    default:
+        return false;
+    }
+
+    return false;   // we should never get here..
+}
+
+bool UVCCtrl::getProperty(uint32_t propID, int32_t *value)
+{
+    if (m_controller == nullptr)
+    {
+        return false;
+    }
+
+    *value = 0;
+
+    switch(propID)
+    {
+    case CAPPROPID_EXPOSURE:
+        return getData(CT_EXPOSURE_TIME_ABSOLUTE_CONTROL, UVC_INPUT_TERMINAL_ID, 4, value);
+    case CAPPROPID_FOCUS:
+        return false; // FIXME: not supported yet
+    case CAPPROPID_ZOOM:
+        return false; // FIXME: not supported yet
+    case CAPPROPID_WHITEBALANCE:
+        return getData(PU_WHITE_BALANCE_TEMPERATURE_CONTROL, UVC_PROCESSING_UNIT_ID, 2, value);       
+    case CAPPROPID_GAIN:
+        return getData(PU_GAIN_CONTROL, UVC_PROCESSING_UNIT_ID, 2, value);
+    default:
+        return false;
+    }
+
+    return false;   // we should never get here..
+}
+
+bool UVCCtrl::setAutoProperty(uint32_t propID, bool enabled)
+{
+    if (m_controller == nullptr)
+    {
+        return false;
+    }
+
+    int32_t value = enabled ? 1 : 0;
+    switch(propID)
+    {
+    case CAPPROPID_EXPOSURE:
+        return setData(CT_AE_MODE_CONTROL, UVC_INPUT_TERMINAL_ID, 1, enabled ? 0x8 : 0x1);
+    case CAPPROPID_WHITEBALANCE:
+        return setData(PU_WHITE_BALANCE_TEMPERATURE_AUTO_CONTROL, UVC_PROCESSING_UNIT_ID, 1, value);
+    default:
+        return false;
+    }
+
+    return false;   // we should never get here..
+}
+
+bool UVCCtrl::getAutoProperty(uint32_t propID, bool &enabled)
+{
+    if (m_controller == nullptr)
+    {
+        return false;
+    }
+    if (m_controller == nullptr)
+    {
+        return false;
+    }
+
+    int32_t value;
+    switch(propID)
+    {
+    case CAPPROPID_EXPOSURE:
+        if (getData(0x02, UVC_INPUT_TERMINAL_ID, 1, &value))
+        {
+            enabled = (value==1) ? true : false; 
+            return true;
+        }
+        return false;
+    case CAPPROPID_WHITEBALANCE:
+        if (getData(0x0B, UVC_PROCESSING_UNIT_ID, 1, &value))
+        {
+            enabled = (value==1) ? true : false; 
+            return true;
+        }
+        return false;
+    default:
+        return false;
+    }
+
+    return false;   // we should never get here..
+}
+
+bool UVCCtrl::getPropertyLimits(uint32_t propID, int32_t *emin, int32_t *emax)
+{
+    if (m_controller == nullptr)
+    {
+        return false;
+    }
+
+    switch(propID)
+    {
+    case CAPPROPID_EXPOSURE:
+        if (!getMinData(CT_EXPOSURE_TIME_ABSOLUTE_CONTROL, UVC_INPUT_TERMINAL_ID, 4, emin))
+        {
+            return false;
+        }
+        if (!getMaxData(CT_EXPOSURE_TIME_ABSOLUTE_CONTROL, UVC_INPUT_TERMINAL_ID, 4, emax))
+        {
+            return false;
+        }
+        return true;
+    case CAPPROPID_FOCUS:
+        if (!getMinData(CT_FOCUS_ABSOLUTE_CONTROL, UVC_INPUT_TERMINAL_ID, 2, emin))
+        {
+            return false;
+        }
+        if (!getMaxData(CT_FOCUS_ABSOLUTE_CONTROL, UVC_INPUT_TERMINAL_ID, 2, emax))
+        {
+            return false;
+        }           
+        return true;
+    case CAPPROPID_ZOOM:
+        if (!getMinData(CT_ZOOM_ABSOLUTE_CONTROL, UVC_INPUT_TERMINAL_ID, 2, emin))
+        {
+            return false;
+        }
+        if (!getMaxData(CT_ZOOM_ABSOLUTE_CONTROL, UVC_INPUT_TERMINAL_ID, 2, emax))
+        {
+            return false;
+        }        
+        return true; 
+    case CAPPROPID_WHITEBALANCE:
+        if (!getMinData(CT_ZOOM_ABSOLUTE_CONTROL, UVC_INPUT_TERMINAL_ID, 2, emin))
+        {
+            return false;
+        }
+        if (!getMaxData(CT_ZOOM_ABSOLUTE_CONTROL, UVC_INPUT_TERMINAL_ID, 2, emax))
+        {
+            return false;
+        }     
+        return true;
+    case CAPPROPID_GAIN:
+        if (!getMinData(PU_GAIN_CONTROL, UVC_PROCESSING_UNIT_ID, 2, emin))
+        {
+            return false;
+        }
+        if (!getMaxData(PU_GAIN_CONTROL, UVC_PROCESSING_UNIT_ID, 2, emax))
+        {
+            return false;
+        }
+        return true;
+    default:
+        return false;
+    }
+
+    return false;   
+}


### PR DESCRIPTION
* Removed old OSX property code: OSX does not have enough native support for UVC.
* Added UVC-only property support.
* Updated OSX test programs.
* This code should be considered experimental and needs to be tested mode in the wild.

Note: There will most certainly be problems on OSX when there are two cameras with the same USB vendor ID and USB product ID. It is likely that only one camera will respond to property updates to both cameras. The way the USB devices and AVFoundation devices are linked must be revisited.