### PR TITLE
OSX: fix UVC camera identification uniqueness

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ OpenPnP Capture is a cross platform video capture library with a focus on machin
 | White balance control | No |
 | Framerate control | No |
 
+# TODO
+* support for re-enumeration.
+* support for setting/getting UVC properties on OSX.
+
 # Building OpenPnP Capture
 
 ### Dependencies

--- a/include/openpnp-capture.h
+++ b/include/openpnp-capture.h
@@ -70,11 +70,17 @@ typedef uint32_t CapResult;     ///< result defined by CAPRESULT_xxx
 typedef uint32_t CapDeviceID;   ///< unique device ID
 typedef uint32_t CapFormatID;   ///< format identifier 0 .. numFormats
 
-#define CAPPROPID_EXPOSURE 1
-#define CAPPROPID_FOCUS 2
-#define CAPPROPID_ZOOM 3
+// supported properties:
+#define CAPPROPID_EXPOSURE     1
+#define CAPPROPID_FOCUS        2
+#define CAPPROPID_ZOOM         3
 #define CAPPROPID_WHITEBALANCE 4
-#define CAPPROPID_GAIN 5
+#define CAPPROPID_GAIN         5
+#define CAPPROPID_BRIGHTNESS   6
+#define CAPPROPID_CONTRAST     7
+#define CAPPROPID_SATURATION   8
+#define CAPPROPID_GAMMA        9
+#define CAPPROPID_LAST         10
 
 typedef uint32_t CapPropertyID; ///< property ID (exposure, zoom, focus etc.)
 

--- a/linux/mjpeghelper.cpp
+++ b/linux/mjpeghelper.cpp
@@ -39,11 +39,24 @@ bool MJPEGHelper::decompressFrame(const uint8_t *inBuffer,
     if (tjDecompress2(m_decompressHandle, jpegPtr, inBytes, outBuffer, 
         width, 0/*pitch*/, height, TJPF_RGB, TJFLAG_FASTDCT) != 0)
     {
-        //FIXME: ignore the compress error for now
-        //       the ELP 720p camera keeps generating JPEG decode
-        //       errors.
-        LOG(LOG_WARNING, "tjDecompress2 failed: %s\n", tjGetErrorStr());
-        //return false;
+        // A lot of cameras produce incorrect but decoding JPEG data
+        // and produce warnings that fill the console,
+        // such as 'extraneous bytes before marker' etc.
+        //
+        // To avoid cluttering the console, we suppress the warnings
+        // and errors completely.. :-/
+        //
+        // FIXME: the following disabled code only works for
+        // very recent libjpeg-turbo libraries that aren't common on systems
+        // yet..
+
+        #if 0
+        if (tjGetErrorCode(m_decompressHandle)==TJERR_ERROR)
+        {
+            LOG(LOG_ERR, "tjDecompress2 failed: %s\n", tjGetErrorStr());
+            return false;
+        }
+        #endif
 
         return true;
     }

--- a/mac/QtCaptureTest/mainwindow.cpp
+++ b/mac/QtCaptureTest/mainwindow.cpp
@@ -74,6 +74,8 @@ MainWindow::MainWindow(QWidget *parent) :
     m_whiteBalanceSlider = new QSlider(Qt::Horizontal);
     m_autoGain = new QCheckBox("Auto Gain");
     m_gainSlider = new QSlider(Qt::Horizontal);
+    m_contrastSlider = new QSlider(Qt::Horizontal);
+    m_brightnessSlider = new QSlider(Qt::Horizontal);
 
     ui->verticalLayout->addWidget(m_autoExposure);
     ui->verticalLayout->addWidget(m_exposureSlider);
@@ -81,6 +83,8 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->verticalLayout->addWidget(m_whiteBalanceSlider);
     ui->verticalLayout->addWidget(m_autoGain);
     ui->verticalLayout->addWidget(m_gainSlider);
+    ui->verticalLayout->addWidget(m_contrastSlider);
+    ui->verticalLayout->addWidget(m_brightnessSlider);
 
     connect(m_autoExposure, SIGNAL(toggled(bool)), this, SLOT(onAutoExposure(bool)));
     connect(m_autoWhiteBalance, SIGNAL(toggled(bool)),this, SLOT(onAutoWhiteBalance(bool)));
@@ -88,7 +92,8 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(m_whiteBalanceSlider, SIGNAL(valueChanged(int)),this, SLOT(onWhiteBalanceSlider(int)));
     connect(m_autoGain, SIGNAL(toggled(bool)), this, SLOT(onAutoGain(bool)));
     connect(m_gainSlider, SIGNAL(valueChanged(int)), this, SLOT(onGainSlider(int)));
-
+    connect(m_contrastSlider, SIGNAL(valueChanged(int)), this, SLOT(onContrastSlider(int)));
+    connect(m_brightnessSlider, SIGNAL(valueChanged(int)), this, SLOT(onBrightnessSlider(int)));
 
     // add timer to refresh the frame display
     m_refreshTimer = new QTimer(this);
@@ -261,6 +266,28 @@ void MainWindow::readCameraSettings()
         qDebug() << "Failed to get gain limits";
         m_gainSlider->setRange(0, 0);
     }
+
+    if (Cap_getPropertyLimits(m_ctx, m_streamID, CAPPROPID_CONTRAST, &emin, &emax)==CAPRESULT_OK)
+    {
+        qDebug() << "Contrast min: " << emin;
+        qDebug() << "Contrast max: " << emax;
+        m_contrastSlider->setRange(emin, emax);
+    }
+    else
+    {
+        m_contrastSlider->setRange(0, 0);
+    }
+
+    if (Cap_getPropertyLimits(m_ctx, m_streamID, CAPPROPID_BRIGHTNESS, &emin, &emax)==CAPRESULT_OK)
+    {
+        qDebug() << "Brightness min: " << emin;
+        qDebug() << "Brightness max: " << emax;
+        m_brightnessSlider->setRange(emin, emax);
+    }
+    else
+    {
+        m_brightnessSlider->setRange(0, 0);
+    }
 }
 
 void MainWindow::onExposureSlider(int value)
@@ -279,4 +306,14 @@ void MainWindow::onWhiteBalanceSlider(int value)
 void MainWindow::onGainSlider(int value)
 {
     Cap_setProperty(m_ctx, m_streamID, CAPPROPID_GAIN, value);
+}
+
+void MainWindow::onContrastSlider(int value)
+{
+    Cap_setProperty(m_ctx, m_streamID, CAPPROPID_CONTRAST, value);
+}
+
+void MainWindow::onBrightnessSlider(int value)
+{
+    Cap_setProperty(m_ctx, m_streamID, CAPPROPID_BRIGHTNESS, value);
 }

--- a/mac/QtCaptureTest/mainwindow.h
+++ b/mac/QtCaptureTest/mainwindow.h
@@ -33,6 +33,8 @@ public slots:
     void onExposureSlider(int value);
     void onWhiteBalanceSlider(int value);
     void onGainSlider(int value);
+    void onContrastSlider(int value);
+    void onBrightnessSlider(int value);
 
 private:
     CapFormatInfo           m_finfo;
@@ -45,7 +47,8 @@ private:
     QSlider*    m_exposureSlider;
     QSlider*    m_whiteBalanceSlider;
     QSlider*    m_gainSlider;
-
+    QSlider*    m_contrastSlider;
+    QSlider*    m_brightnessSlider;
 
     QTimer*     m_refreshTimer;
     CapContext  m_ctx;

--- a/mac/platformdeviceinfo.h
+++ b/mac/platformdeviceinfo.h
@@ -53,8 +53,9 @@ public:
 
     // save USB PID/VID so we can access the UVC camera
     // directly for setting focus/exposure etc.
-    uint16_t m_pid; // USB product ID (if found) 
-    uint16_t m_vid; // USB vendor ID (if found)
+    uint16_t m_pid;         // USB product ID (if found) 
+    uint16_t m_vid;         // USB vendor ID (if found)
+    uint32_t m_busLocation; // 10-char hex bus location (if found)
 };
 
 #endif

--- a/mac/platformstream.mm
+++ b/mac/platformstream.mm
@@ -212,37 +212,6 @@ bool PlatformStream::open(Context *owner, deviceInfo *device, uint32_t width, ui
     [m_nativeSession addOutput:output];
     output.videoSettings = nil;
 
-#if 0
-    //auto myFormat = nativeDevice.activeFormat.formatDescription;
-    //NSLog(@"%@", myFormat);
-
-    //for (NSString *key in [myFormat allKeys]) 
-    //{
-        //NSString *v = [output.videoSettings objectForKey:key];
-        //LOG(LOG_DEBUG,"key: %s %s\n", key.UTF8String, v.UTF8String);
-        //NSLog(@"%@",[myFormat objectForKey:key]);
-    //}
-
-    // dump all video settings
-    LOG(LOG_DEBUG,"Dumping videoSettings:\n");
-    for (NSString *key in [output.videoSettings allKeys]) 
-    {
-        //NSString *v = [output.videoSettings objectForKey:key];
-        //LOG(LOG_DEBUG,"key: %s %s\n", key.UTF8String, v.UTF8String);
-        NSLog(@"%@",[output.videoSettings objectForKey:key]);
-    }
-
-    output.videoSettings = [NSDictionary dictionaryWithObjectsAndKeys:
-        [output.videoSettings objectForKey:AVVideoCodecKey], AVVideoCodecKey,
-        [NSNumber numberWithUnsignedInt:kCVPixelFormatType_32BGRA], (id)kCVPixelBufferPixelFormatTypeKey,
-        //[NSNumber numberWithInt:width], AVVideoWidthKey,
-        //[NSNumber numberWithInt:height], AVVideoHeightKey,
-        //[NSNumber numberWithUnsignedInt:width], AVVideoWidthKey,
-        //[NSNumber numberWithUnsignedInt:height], AVVideoHeightKey,
-         nil];
-
-#endif
-
     output.videoSettings = [NSDictionary dictionaryWithObjectsAndKeys:
         [NSNumber numberWithUnsignedInt:kCVPixelFormatType_32ARGB], (id)kCVPixelBufferPixelFormatTypeKey,
         nil];
@@ -275,7 +244,7 @@ bool PlatformStream::open(Context *owner, deviceInfo *device, uint32_t width, ui
     [m_device unlockForConfiguration];
 
     // try to create a UVC control object
-    m_uvc = UVCCtrl::create(dinfo->m_vid, dinfo->m_pid);
+    m_uvc = UVCCtrl::create(dinfo->m_vid, dinfo->m_pid, dinfo->m_busLocation);
     if (m_uvc != nullptr)
     {
         LOG(LOG_DEBUG, "Created a UVC control object!\n");

--- a/mac/tests/main.cpp
+++ b/mac/tests/main.cpp
@@ -106,8 +106,8 @@ int main(int argc, char*argv[])
             for (int i = 3; i >= 0; i--) {
                 fourcc += (char) ((finfo.fourcc >> (8 * i)) & 0xff);
             }
-            printf("  Format ID %d: %d x %d pixels  FOURCC=%s\n",
-                j, finfo.width, finfo.height, fourcc.c_str());
+            printf("  Format ID %d: %d x %d pixels  %d FPS(max)  FOURCC=%s\n",
+                j, finfo.width, finfo.height, finfo.fps, fourcc.c_str());
         }
     }
 

--- a/mac/uvcctrl.h
+++ b/mac/uvcctrl.h
@@ -27,10 +27,17 @@ class UVCCtrl
 public:
     virtual ~UVCCtrl();
 
-    /** create a UVC controller for a USB camera */
-    static UVCCtrl* create(uint16_t vid, uint16_t pid)
+    /** create a UVC controller for a USB camera based on its 
+        USB vendor ID (vid), USB product ID (pid) and the
+        bus location.
+
+        If the bus location is unknown, set it to zero. In this case,
+        a control interface to the first matching VID/PID device is
+        returned.
+    */
+    static UVCCtrl* create(uint16_t vid, uint16_t pid, uint32_t location)
     {
-        IOUSBDeviceInterface** dev = findDevice(vid, pid);
+        IOUSBDeviceInterface** dev = findDevice(vid, pid, location);
         if (dev != nullptr)
         {
             uint32_t unitID = getProcessingUnitID(dev);
@@ -53,7 +60,7 @@ public:
 protected:
     UVCCtrl(IOUSBInterfaceInterface190 **controller, uint32_t processingUnitID);
 
-    static IOUSBDeviceInterface** findDevice(uint16_t vid, uint16_t pid);
+    static IOUSBDeviceInterface** findDevice(uint16_t vid, uint16_t pid, uint32_t location);
     static IOUSBInterfaceInterface190** createControlInterface(IOUSBDeviceInterface** deviceInterface);
     static uint32_t getProcessingUnitID(IOUSBDeviceInterface**);
 

--- a/mac/uvcctrl.mm
+++ b/mac/uvcctrl.mm
@@ -87,7 +87,7 @@ UVCCtrl::~UVCCtrl()
     }
 }
 
-IOUSBDeviceInterface** UVCCtrl::findDevice(uint16_t vid, uint16_t pid)
+IOUSBDeviceInterface** UVCCtrl::findDevice(uint16_t vid, uint16_t pid, uint32_t location)
 {
     LOG(LOG_DEBUG, "UVCCtrl::findDevice() called\n");
 
@@ -118,7 +118,6 @@ IOUSBDeviceInterface** UVCCtrl::findDevice(uint16_t vid, uint16_t pid)
                 CFUUIDGetUUIDBytes(kIOUSBDeviceInterfaceID),
                 (LPVOID*)&deviceInterface);
 
-
             if (hr || (deviceInterface == nullptr))
             {
                 (*plugInInterface)->Release(plugInInterface);
@@ -127,10 +126,19 @@ IOUSBDeviceInterface** UVCCtrl::findDevice(uint16_t vid, uint16_t pid)
             }
 
             uint16_t vendorID, productID;
+            uint32_t locationID;
             result = (*deviceInterface)->GetDeviceVendor(deviceInterface, &vendorID);
             result = (*deviceInterface)->GetDeviceProduct(deviceInterface, &productID);
+            result = (*deviceInterface)->GetLocationID(deviceInterface, &locationID);
 
-            if ((vendorID == vid) && (productID == pid))
+            // if 'location' is zero, we won't match on location
+            // to achieve this, we simply set locationID to zero.
+            if (location == 0)
+            {
+                locationID = 0;
+            }
+
+            if ((vendorID == vid) && (productID == pid) && (locationID == location))
             {
                 (*plugInInterface)->Release(plugInInterface);
                 return deviceInterface;

--- a/mac/uvcctrl.mm
+++ b/mac/uvcctrl.mm
@@ -24,7 +24,6 @@
 //
 
 #define UVC_INPUT_TERMINAL_ID 0x01
-#define UVC_PROCESSING_UNIT_ID 0x03
 
 // Camera termainal control selectors
 #define CT_AE_MODE_CONTROL 0x02
@@ -41,9 +40,13 @@
 #define PU_BRIGHTNESS_CONTROL 0x02
 #define PU_CONTRAST_CONTROL 0x03
 #define PU_GAIN_CONTROL 0x04
+#define PU_HUE_CONTROL 0x06
+#define PU_SATURATION_CONTROL 0x07
+#define PU_SHARPNESS_CONTROL 0x08
+#define PU_GAMMA_CONTROL 0x09
 #define PU_WHITE_BALANCE_TEMPERATURE_CONTROL 0x0A
 #define PU_WHITE_BALANCE_TEMPERATURE_AUTO_CONTROL 0x0B
-#define PA_WHITE_BALANCE_COMPONENT_CONTROL 0x0C
+#define PU_WHITE_BALANCE_COMPONENT_CONTROL 0x0C
 #define PU_WHITE_BALANCE_COMPONENT_AUTO_CONTROL 0x0D
 #define PU_HUE_AUTO_CONTROL 0x10
 #define PU_CONTRAST_AUTO_CONTROL 0x13
@@ -62,6 +65,7 @@
 #define UVC_GET_INFO 0x86
 #define UVC_GET_DEF 0x87
 
+// USB descriptor for UVC processing unit
 struct ProcessingUnitDescriptor
 {
     uint8_t bLength;
@@ -70,12 +74,33 @@ struct ProcessingUnitDescriptor
     uint8_t bUnitID;
 };
 
+struct propertyInfo_t
+{
+    uint32_t    selector;   // selector ID
+    uint32_t    unit;       // unit (==0 for INPUT TERMINA:, ==1 for PROCESSING UNIT)
+    uint32_t    length;     // length (bytes)
+};
+
+const propertyInfo_t propertyInfo[] =
+{
+    {0,0,0},
+    {CT_EXPOSURE_TIME_ABSOLUTE_CONTROL   , 0, 4},
+    {CT_FOCUS_ABSOLUTE_CONTROL           , 0, 2},
+    {CT_ZOOM_ABSOLUTE_CONTROL            , 0, 2},
+    {PU_WHITE_BALANCE_TEMPERATURE_CONTROL, 1, 2},
+    {PU_GAIN_CONTROL                     , 1, 2},
+    {PU_BRIGHTNESS_CONTROL               , 1, 2},
+    {PU_CONTRAST_CONTROL                 , 1, 2},
+    {PU_SATURATION_CONTROL               , 1, 2},
+    {PU_GAMMA_CONTROL                    , 1, 2}
+};
+
 UVCCtrl::UVCCtrl(IOUSBInterfaceInterface190 **controller, uint32_t processingUnitID)
     : m_pud(processingUnitID),
     m_controller(controller)
 {
-    LOG(LOG_VERBOSE,"[BRIGHTNESS] ");
-    reportCapabilities(PU_BRIGHTNESS_CONTROL, UVC_PROCESSING_UNIT_ID);        
+    //LOG(LOG_VERBOSE,"[BRIGHTNESS] ");
+    //reportCapabilities(PU_BRIGHTNESS_CONTROL, UVC_PROCESSING_UNIT_ID);        
 }
 
 UVCCtrl::~UVCCtrl()
@@ -190,17 +215,15 @@ uint32_t UVCCtrl::getProcessingUnitID(IOUSBDeviceInterface** dev)
         while(idx < configDesc->wTotalLength)
         {
             IOUSBDescriptorHeader *hdr = (IOUSBDescriptorHeader *)&ptr[idx];
-            //LOG(LOG_VERBOSE, "LEN  %08X\n", hdr->bLength);
-            //LOG(LOG_VERBOSE, "TYPE %08X ", hdr->bDescriptorType);
             switch(hdr->bDescriptorType)
             {
-                case 0x05:
+                case 0x05:  // Endpoint descriptor ID
                     LOG(LOG_VERBOSE,"Endpoint\n");
                     break;
-                case 0x02:
+                case 0x02:  // Configuration descriptor ID
                     LOG(LOG_VERBOSE,"Configuration\n");
                     break;
-                case 0x04:
+                case 0x04: // Interface descriptor ID
                     LOG(LOG_VERBOSE,"Interface");
                     iface = (IOUSBInterfaceDescriptor*)&ptr[idx];
                     if ((iface->bInterfaceClass == 14) && 
@@ -215,7 +238,8 @@ uint32_t UVCCtrl::getProcessingUnitID(IOUSBDeviceInterface** dev)
                         inVideoControlInterfaceDescriptor = false;
                         LOG(LOG_VERBOSE,"\n");
                     }
-                case 0x24:
+                    break;
+                case 0x24: // class-specific ID
                     pud = (ProcessingUnitDescriptor*)&ptr[idx];
                     if (inVideoControlInterfaceDescriptor)
                     {
@@ -226,10 +250,10 @@ uint32_t UVCCtrl::getProcessingUnitID(IOUSBDeviceInterface** dev)
                             return pud->bUnitID;
                         }
                     }
-                    LOG(LOG_VERBOSE,"\n");
+                    //LOG(LOG_VERBOSE,"\n");
                     break;
                 default:
-                    LOG(LOG_VERBOSE,"?\n");
+                    //LOG(LOG_VERBOSE,"?\n");
                     break;
             }
             idx += hdr->bLength; // skip to next..
@@ -433,6 +457,16 @@ bool UVCCtrl::setProperty(uint32_t propID, int32_t value)
         return false;
     }
 
+    bool ok = false;
+    if (propID < CAPPROPID_LAST)
+    {
+        uint32_t unit = (propertyInfo[propID].unit == 0) ? UVC_INPUT_TERMINAL_ID : m_pud;
+        ok = setData(propertyInfo[propID].selector, unit, 
+            propertyInfo[propID].length, value);
+    }
+    return ok;
+
+#if 0
     switch(propID)
     {
     case CAPPROPID_EXPOSURE:
@@ -453,7 +487,9 @@ bool UVCCtrl::setProperty(uint32_t propID, int32_t value)
         return false;
     }
 
-    return false;   // we should never get here..
+    return false;   // we should never get here..    
+#endif
+
 }
 
 bool UVCCtrl::getProperty(uint32_t propID, int32_t *value)
@@ -463,8 +499,29 @@ bool UVCCtrl::getProperty(uint32_t propID, int32_t *value)
         return false;
     }
 
-    *value = 0;
+    bool ok = false;
+    if (propID < CAPPROPID_LAST)
+    {
+        uint32_t unit = (propertyInfo[propID].unit == 0) ? UVC_INPUT_TERMINAL_ID : m_pud;
+        ok = getData(propertyInfo[propID].selector, unit, 
+            propertyInfo[propID].length, value);
 
+        switch(propertyInfo[propID].length)
+        {
+            case 2:
+                *value &= 0xFFFF;
+                break;
+            case 1:
+                *value &= 0xFF;
+                break;
+            default:
+                break;
+        }
+    }
+    return ok;
+
+#if 0
+    *value = 0;
     uint32_t info;
     switch(propID)
     {
@@ -482,12 +539,13 @@ bool UVCCtrl::getProperty(uint32_t propID, int32_t *value)
         return getData(PU_WHITE_BALANCE_TEMPERATURE_CONTROL, UVC_PROCESSING_UNIT_ID, 2, value);       
     case CAPPROPID_GAIN:
         LOG(LOG_VERBOSE, "UVCCtrl::getProperty (gain)\n");
-        return getData(PU_GAIN_CONTROL, UVC_PROCESSING_UNIT_ID, 2, value);
+        return getData(PU_GAIN_CONTROL, UVC_PROCESSING_UNIT_ID, 2, value);    
     default:
         return false;
     }
 
     return false;   // we should never get here..
+#endif
 }
 
 bool UVCCtrl::setAutoProperty(uint32_t propID, bool enabled)
@@ -505,7 +563,7 @@ bool UVCCtrl::setAutoProperty(uint32_t propID, bool enabled)
         return setData(CT_AE_MODE_CONTROL, UVC_INPUT_TERMINAL_ID, 1, enabled ? 0x8 : 0x1);
     case CAPPROPID_WHITEBALANCE:
         LOG(LOG_VERBOSE, "UVCCtrl::setAutoProperty (white balance %s)\n", enabled ? "ON" : "OFF");
-        return setData(PU_WHITE_BALANCE_TEMPERATURE_AUTO_CONTROL, UVC_PROCESSING_UNIT_ID, 1, value);
+        return setData(PU_WHITE_BALANCE_TEMPERATURE_AUTO_CONTROL, m_pud, 1, value);
     default:
         return false;
     }
@@ -541,7 +599,7 @@ bool UVCCtrl::getAutoProperty(uint32_t propID, bool *enabled)
         return false;
     case CAPPROPID_WHITEBALANCE:
         LOG(LOG_VERBOSE, "UVCCtrl::getAutoProperty white balance\n");
-        if (getData(PU_WHITE_BALANCE_TEMPERATURE_AUTO_CONTROL, UVC_PROCESSING_UNIT_ID, 1, &value))
+        if (getData(PU_WHITE_BALANCE_TEMPERATURE_AUTO_CONTROL, m_pud, 1, &value))
         {
             LOG(LOG_VERBOSE,"PU_WHITE_BALANCE_TEMPERATURE_AUTO_CONTROL returned %08Xh\n", value & 0xFF);
             value &= 0xFF; // make 8-bit            
@@ -563,6 +621,44 @@ bool UVCCtrl::getPropertyLimits(uint32_t propID, int32_t *emin, int32_t *emax)
         return false;
     }
 
+    bool ok = false;
+    if (propID < CAPPROPID_LAST)
+    {
+        uint32_t unit = (propertyInfo[propID].unit == 0) ? UVC_INPUT_TERMINAL_ID : m_pud;
+        if (getMinData(propertyInfo[propID].selector, unit, 
+            propertyInfo[propID].length, emin))
+        {
+            ok = true;
+        }
+
+        if (getMaxData(propertyInfo[propID].selector, unit, 
+            propertyInfo[propID].length, emax))
+        {
+            // do not set ok to true here
+            // in case getMinData failed..
+        }
+        else
+        {
+            ok = false;
+        }
+
+        switch(propertyInfo[propID].length)
+        {
+            case 2:
+                *emin &= 0xFFFF;
+                *emax &= 0xFFFF;
+                break;
+            case 1:
+                *emin &= 0xFF;
+                *emax &= 0xFF;
+                break;
+            default:
+                break;
+        }
+    }
+    return ok;
+
+#if 0
     switch(propID)
     {
     case CAPPROPID_EXPOSURE:
@@ -642,6 +738,7 @@ bool UVCCtrl::getPropertyLimits(uint32_t propID, int32_t *emin, int32_t *emax)
     }
 
     return false;   
+#endif
 }
 
 void UVCCtrl::reportCapabilities(uint32_t selector, uint32_t unit)


### PR DESCRIPTION
* Fixed OSX UVC problem where cameras that have the same VID/PID could not be uniquely identified by the UVC property control system, leaving the second, third etc. uncontrollable.
* Added gamma, brightness, contrast and saturation properties to the library.
* Implemented control of the aforementioned properties on OSX (win+linux still need updates).
* Updated OSX test programs.