### PR TITLE
OSX: Add support for enable / disable autofocus

### DIFF
--- a/QtCaptureTest/mainwindow.cpp
+++ b/QtCaptureTest/mainwindow.cpp
@@ -87,6 +87,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->exposureSlider, SIGNAL(valueChanged(int)),this, SLOT(onExposureSlider(int)));
     connect(ui->whitebalanceSlider, SIGNAL(valueChanged(int)),this, SLOT(onWhiteBalanceSlider(int)));
     connect(ui->autoGain, SIGNAL(toggled(bool)), this, SLOT(onAutoGain(bool)));
+    connect(ui->autoFocus, SIGNAL(toggled(bool)), this, SLOT(onAutoFocus(bool)));
     connect(ui->gainSlider, SIGNAL(valueChanged(int)), this, SLOT(onGainSlider(int)));
     connect(ui->contrastSlider, SIGNAL(valueChanged(int)), this, SLOT(onContrastSlider(int)));
     connect(ui->brightnessSlider, SIGNAL(valueChanged(int)), this, SLOT(onBrightnessSlider(int)));
@@ -226,6 +227,13 @@ void MainWindow::onAutoGain(bool state)
     ui->gainSlider->setEnabled((!state) & m_hasGain);
 }
 
+void MainWindow::onAutoFocus(bool state)
+{
+    qDebug() << "Auto focus set to " << state;
+    Cap_setAutoProperty(m_ctx, m_streamID, CAPPROPID_FOCUS, state ? 1 : 0);
+    ui->gainSlider->setEnabled((!state) & m_hasGain);
+}
+
 void MainWindow::readCameraSettings()
 {
     qDebug() << "readCameraSettings -> Context = " << m_ctx;
@@ -248,6 +256,7 @@ void MainWindow::readCameraSettings()
     ui->exposureSlider->setEnabled(false);
     ui->gainSlider->setEnabled(false);
     ui->whitebalanceSlider->setEnabled(false);
+    ui->focusSlider->setEnabled(false);
 
     // ********************************************************************************
     //   AUTO EXPOSURE
@@ -293,6 +302,23 @@ void MainWindow::readCameraSettings()
     {
         ui->autoWhiteBalance->setEnabled(true);
         ui->autoWhiteBalance->setCheckState((bValue==0) ? Qt::Unchecked : Qt::Checked);
+    }
+
+    // ********************************************************************************
+    //   AUTO FOCUS
+    // ********************************************************************************
+
+    if (Cap_getAutoProperty(m_ctx, m_streamID, CAPPROPID_FOCUS, &bValue) != CAPRESULT_OK)
+    {
+        qDebug() << "Autofocus unsupported";
+        ui->autoFocus->setEnabled(false);
+        ui->autoFocus->setCheckState(Qt::Unchecked);
+    }
+    else
+    {
+        qDebug() << "Autofocus supported";
+        ui->autoFocus->setEnabled(true);
+        ui->autoFocus->setCheckState((bValue==0) ? Qt::Unchecked : Qt::Checked);
     }
 
     // ********************************************************************************

--- a/QtCaptureTest/mainwindow.h
+++ b/QtCaptureTest/mainwindow.h
@@ -41,6 +41,7 @@ public slots:
     void onAutoExposure(bool state);
     void onAutoWhiteBalance(bool state);
     void onAutoGain(bool state);
+    void onAutoFocus(bool state);
     void onExposureSlider(int value);
     void onWhiteBalanceSlider(int value);
     void onGainSlider(int value);

--- a/QtCaptureTest/mainwindow.ui
+++ b/QtCaptureTest/mainwindow.ui
@@ -61,21 +61,21 @@
           <string>Camera Settings</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="13" column="1">
+          <item row="14" column="1">
            <widget class="QSlider" name="sharpnessSlider">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
            </widget>
           </item>
-          <item row="15" column="1">
+          <item row="16" column="1">
            <widget class="QSlider" name="powerlineFreqSlider">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
            </widget>
           </item>
-          <item row="15" column="0">
+          <item row="16" column="0">
            <widget class="QLabel" name="label_13">
             <property name="text">
              <string>Power line freq</string>
@@ -159,7 +159,7 @@
             </property>
            </widget>
           </item>
-          <item row="14" column="0">
+          <item row="15" column="0">
            <widget class="QLabel" name="label_8">
             <property name="text">
              <string>Zoom</string>
@@ -180,7 +180,7 @@
             </property>
            </widget>
           </item>
-          <item row="14" column="1">
+          <item row="15" column="1">
            <widget class="QSlider" name="zoomSlider">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -212,6 +212,13 @@
            <widget class="QSlider" name="focusSlider">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="13" column="1">
+           <widget class="QCheckBox" name="autoFocus">
+            <property name="text">
+             <string>Auto Focus</string>
             </property>
            </widget>
           </item>
@@ -257,7 +264,7 @@
             </property>
            </widget>
           </item>
-          <item row="13" column="0">
+          <item row="14" column="0">
            <widget class="QLabel" name="label_12">
             <property name="text">
              <string>Sharpness</string>

--- a/mac/uvcctrl.mm
+++ b/mac/uvcctrl.mm
@@ -607,6 +607,9 @@ bool UVCCtrl::setAutoProperty(uint32_t propID, bool enabled)
     case CAPPROPID_WHITEBALANCE:
         LOG(LOG_VERBOSE, "UVCCtrl::setAutoProperty (white balance %s)\n", enabled ? "ON" : "OFF");
         return setData(PU_WHITE_BALANCE_TEMPERATURE_AUTO_CONTROL, m_pud, 1, value);
+    case CAPPROPID_FOCUS:
+        LOG(LOG_VERBOSE, "UVCCtrl::setAutoProperty (focus %s)\n", enabled ? "ON" : "OFF");
+        return setData(CT_FOCUS_AUTO_CONTROL, UVC_INPUT_TERMINAL_ID, 1, value);
     default:
         return false;
     }
@@ -649,7 +652,16 @@ bool UVCCtrl::getAutoProperty(uint32_t propID, bool *enabled)
             *enabled = (value==1) ? true : false; 
             return true;
         }
-        return false;     
+        return false;
+    case CAPPROPID_FOCUS:
+        LOG(LOG_VERBOSE, "UVCCtrl::getAutoProperty focus\n");
+        if (getData(CT_FOCUS_AUTO_CONTROL, UVC_INPUT_TERMINAL_ID, 1, &value))
+        {
+            LOG(LOG_VERBOSE,"CT_FOCUS_AUTO_CONTROL returned %08Xh\n", value & 0xFF);
+            value &= 0xFF; // make 8-bit
+            *enabled = (value==1) ? true : false;
+            return true;
+        }
     default:
         return false;
     }


### PR DESCRIPTION
`getAutoProperty()` and `setAutoProperty()` for `CT_FOCUS_AUTO_CONTROL` on OSX wasn't implemented. 

Tested with a Logitech C930e on OSX 10.13 with QTCaptureTest.