### PR TITLE
Fixed macOS Catalina camera permissions request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ common/version.h
 QtCaptureTest/build
 .DS_Store
 .vscode
+.idea/
+cmake-build-*/

--- a/mac/platformcontext.h
+++ b/mac/platformcontext.h
@@ -55,7 +55,8 @@ protected:
         information into the m_devices array 
     */
     virtual bool enumerateDevices();
-
+private:
+    int cameraPermissionReceived; // 0 = waiting, 1 = success, -1 = error
 };
 
 #endif


### PR DESCRIPTION
### Issue
`openpnp-capture-test` fails on MacOS Catalina 10.15.2, MacBookPro 15 2017 internal camera

### Cause
Not waiting for user to grant camera permission

### Fix
Wait for permission granted