### PR TITLE
linux: Fix memory corruption on stream stop

### DIFF
--- a/linux/platformstream.cpp
+++ b/linux/platformstream.cpp
@@ -361,7 +361,6 @@ void PlatformStream::close()
     m_owner = nullptr;
     m_width = 0;
     m_height = 0;
-    m_frameBuffer.resize(0);
     m_isOpen = false; 
     m_quitThread = true;
 
@@ -374,6 +373,7 @@ void PlatformStream::close()
         m_helperThread = nullptr;
     }
 
+    m_frameBuffer.resize(0);
     ::close(m_deviceHandle);
 
     m_deviceHandle = -1;    


### PR DESCRIPTION
The buffer (m_frameBuffer) must not be freed until the capture thread
(m_helperThread) is joined.

Fixes #41.

Signed-off-by: Christopher N. Hesse <raymanfx@gmail.com>