### PR TITLE
Support for Open Broadcasting Studio's Virtual Cameras

### DIFF
--- a/win/platformcontext.cpp
+++ b/win/platformcontext.cpp
@@ -452,20 +452,26 @@ HRESULT FindCaptureDevice(IBaseFilter** ppSrcFilter, const wchar_t* devicePath)
             VariantInit(&varName);
             hr = pbag->Read(L"DevicePath", &varName, 0);
 
+            if(varName.vt==VT_EMPTY){
+            // no device path
+            // fall back to friendlyName
+                hr = pbag->Read(L"FriendlyName", &varName, 0);
+            }
+
             if (SUCCEEDED(hr)) {
                 if (strDevicePath == varName.bstrVal)
                     bMatch = true;
+
             }
             VariantClear(&varName);
-
             if (bMatch)
             {
                 hr = pMoniker->BindToObject(0, 0, IID_PPV_ARGS(ppSrcFilter));
                 return hr;
             }
+
         }
     }
-
     return E_FAIL;
 }
 

--- a/win/platformstream.cpp
+++ b/win/platformstream.cpp
@@ -195,6 +195,11 @@ bool PlatformStream::open(Context *owner, deviceInfo *device, uint32_t width, ui
         return false;
     }
 
+    // virtual cameras may not provide a valid devicepath;
+    if(dinfo->m_devicePath.empty()){
+        dinfo->m_devicePath = dinfo->m_filterName;
+    }
+
     m_owner = owner;
     m_frames = 0;
     m_width = 0;
@@ -339,10 +344,12 @@ bool PlatformStream::open(Context *owner, deviceInfo *device, uint32_t width, ui
     // create camera control interface for exposure control etc . 
     m_camControl = nullptr;
     hr = m_sourceFilter->QueryInterface(IID_IAMCameraControl, (void **)&m_camControl); 
+
     if (hr != S_OK) 
     {
         LOG(LOG_ERR,"Could not create IAMCameraControl\n");
-        return false;  
+        // BROKEN
+        // return false;  
     }
 
     dumpCameraProperties();

--- a/win/platformstream.cpp
+++ b/win/platformstream.cpp
@@ -195,7 +195,8 @@ bool PlatformStream::open(Context *owner, deviceInfo *device, uint32_t width, ui
         return false;
     }
 
-    // virtual cameras may not provide a valid devicepath;
+    // virtual cameras may not provide a valid devicepath
+    // fill devicePath with friendly name
     if(dinfo->m_devicePath.empty()){
         dinfo->m_devicePath = dinfo->m_filterName;
     }
@@ -347,8 +348,8 @@ bool PlatformStream::open(Context *owner, deviceInfo *device, uint32_t width, ui
 
     if (hr != S_OK) 
     {
+        // note: OBS virtual camera does not provide a control interface
         LOG(LOG_ERR,"Could not create IAMCameraControl\n");
-        // BROKEN
         // return false;  
     }
 


### PR DESCRIPTION
Note - the code in this PR is non-functional but allows me to communicate some of the things I have tried whilst attempting to stream from OSB's virtual camera on Windows (OSB version 27.1.1).

I was able to hack in some changes that handle the following issues when working with the OBS virtual camera
1.) The device path query returns an empty result
2.) The device provides no control interface

The changes in this PR allow for a stream to be opened but the capture data is only valid when MSVC's debugger is connected but I have no idea what might be the issue 😢 