### PR TITLE
Wine support

### DIFF
--- a/win/platformcontext.cpp
+++ b/win/platformcontext.cpp
@@ -312,13 +312,6 @@ bool PlatformContext::enumerateFrameInfo(IMoniker *moniker, platformDeviceInfo *
 
     ScopedComPtr<IBaseFilter> baseFilter(pCap);
 
-    hr = baseFilter->EnumPins(&pEnum);
-    if (FAILED(hr))
-    {
-        LOG(LOG_ERR, "No frame information: EnumPins failed.\n");
-        return false;
-    }
-
     if (FindPinByCategory(pCap, PINDIR_OUTPUT, PIN_CATEGORY_CAPTURE, &pPin) == S_OK)
     {
         LOG(LOG_INFO, "Capture pin found!\n");

--- a/win/platformstream.cpp
+++ b/win/platformstream.cpp
@@ -460,14 +460,6 @@ bool PlatformStream::open(Context *owner, deviceInfo *device, uint32_t width, ui
         return false;
     }
 
-    LONGLONG start=0, stop=MAXLONGLONG;
-    hr = m_capture->ControlStream(&PIN_CATEGORY_PREVIEW, &MEDIATYPE_Video, m_sourceFilter, &start, &stop, 1,2);
-    if (hr < 0)
-    {
-        LOG(LOG_ERR,"Could not start the video stream (HRESULT=%08X)\n", hr);
-        return false;
-    }    
-
     // look up the media type:
     AM_MEDIA_TYPE* info = new AM_MEDIA_TYPE();
     hr = m_sampleGrabber->GetConnectedMediaType(info);

--- a/win/platformstream.cpp
+++ b/win/platformstream.cpp
@@ -341,8 +341,8 @@ bool PlatformStream::open(Context *owner, deviceInfo *device, uint32_t width, ui
     hr = m_sourceFilter->QueryInterface(IID_IAMCameraControl, (void **)&m_camControl); 
     if (hr != S_OK) 
     {
-        LOG(LOG_ERR,"Could not create IAMCameraControl\n");
-        return false;  
+        // note: this is not an error because some cameras do not support camera control
+        LOG(LOG_WARNING,"Could not create IAMCameraControl\n");
     }
 
     dumpCameraProperties();


### PR DESCRIPTION
This PR omits some redundant checkings and adds DevicePath to device index fallback feature. It enables software using openpnp-capture to be executed with Wine>=6.0.2 at least. This fallback feature may relates to #49.