### PR TITLE
Don't open & close control channel on macOS Monterey

### DIFF
--- a/mac/uvcctrl.mm
+++ b/mac/uvcctrl.mm
@@ -356,11 +356,19 @@ bool UVCCtrl::sendControlRequest(IOUSBDevRequest req)
         return false;
     }
 
-    kern_return_t kr = (*m_controller)->USBInterfaceOpen(m_controller);
-    if (kr != kIOReturnSuccess)
+    kern_return_t kr;
+    if (@available(macOS 12.0, *))
     {
-        LOG(LOG_ERR, "sendControlRequest USBInterfaceOpen failed!\n");
-        return false;
+        // macOS 12 doesn't like if we're trying to open USB interface here...
+    }
+    else
+    {
+        kr = (*m_controller)->USBInterfaceOpen(m_controller);
+        if (kr != kIOReturnSuccess)
+        {
+            LOG(LOG_ERR, "sendControlRequest USBInterfaceOpen failed!\n");
+            return false;
+        }
     }
 
     kr = (*m_controller)->ControlRequest(m_controller, 0, &req);
@@ -403,11 +411,34 @@ bool UVCCtrl::sendControlRequest(IOUSBDevRequest req)
                 break; 
         }
 
-        kr = (*m_controller)->USBInterfaceClose(m_controller);
+        if (@available(macOS 12.0, *))
+        {
+            // macOS 12 doesn't like if we're trying to close USB interface here...
+        }
+        else
+        {
+            kr = (*m_controller)->USBInterfaceClose(m_controller);
+            if (kr != kIOReturnSuccess) {
+                LOG(LOG_ERR, "sendControlRequest USBInterfaceClose failed!\n");
+            }
+        }
+
         return false;
     }
 
-    kr = (*m_controller)->USBInterfaceClose(m_controller);
+    if (@available(macOS 12.0, *))
+    {
+        // macOS 12 doesn't like if we're trying to close USB interface here either...
+    }
+    else
+    {
+        kr = (*m_controller)->USBInterfaceClose(m_controller);
+        if (kr != kIOReturnSuccess)
+        {
+            LOG(LOG_ERR, "sendControlRequest USBInterfaceClose failed!\n");
+        }
+    }
+
     return true;
 }
 


### PR DESCRIPTION
If we skip opening and closing of control channel on macOS Monterey, test application will work fine


```
svenn@MacBook-Pro tests % ./openpnp-capture-test 1
==============================
 OpenPNP Capture Test Program
 OSX 64 bit debug v0.0.22-6-gf9328d4 Mar 10 2022 
==============================
[INFO] Platform context created
2022-03-10 16:06:17.502 openpnp-capture-test[41713:20524518] Already have camera permission
[DBG ] enumerateDevices called
[DBG ] Name : FaceTime HD Camera (Apple Inc.)
[DBG ] Model: FaceTime HD Camera
[DBG ] U ID : FaceTime HD Camera (Apple Inc.) 47B4B64B70674B9CAD2BAE273A71F4B5
OSX Unable to extract vendor ID
OSX Unable to extract product ID
[DBG ] USB      : vid=0000  pid=0000
OSX Unique ID is not exactly 18 characters - wrong format to extract location.
We might have trouble identifying the UVC control interface.
[DBG ] Name : BRIO 4K Stream Edition (Unknown)
[DBG ] Model: UVC Camera VendorID_1133 ProductID_2155
[DBG ] U ID : BRIO 4K Stream Edition (Unknown) 0x2240000046d086b
[DBG ] USB      : vid=046D  pid=086B
OSX Unique ID is not exactly 18 characters - wrong format to extract location.
We might have trouble identifying the UVC control interface.
Number of devices: 2
ID 0 -> FaceTime HD Camera (Apple Inc.)
Unique:  FaceTime HD Camera (Apple Inc.) 47B4B64B70674B9CAD2BAE273A71F4B5
  Number of formats: 7
  Format ID 0: 1920 x 1080 pixels  30 FPS(max)  FOURCC=420v
  Format ID 1: 1280 x 720 pixels  30 FPS(max)  FOURCC=420v
  Format ID 2: 1080 x 1920 pixels  30 FPS(max)  FOURCC=420v
  Format ID 3: 1760 x 1328 pixels  30 FPS(max)  FOURCC=420v
  Format ID 4: 640 x 480 pixels  30 FPS(max)  FOURCC=420v
  Format ID 5: 1328 x 1760 pixels  30 FPS(max)  FOURCC=420v
  Format ID 6: 1552 x 1552 pixels  30 FPS(max)  FOURCC=420v
ID 1 -> BRIO 4K Stream Edition (Unknown)
Unique:  BRIO 4K Stream Edition (Unknown) 0x2240000046d086b
  Number of formats: 41
  Format ID 0: 160 x 120 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 1: 160 x 120 pixels  30 FPS(max)  FOURCC=420v
  Format ID 2: 176 x 144 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 3: 176 x 144 pixels  30 FPS(max)  FOURCC=420v
  Format ID 4: 320 x 180 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 5: 320 x 180 pixels  30 FPS(max)  FOURCC=420v
  Format ID 6: 320 x 240 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 7: 320 x 240 pixels  30 FPS(max)  FOURCC=420v
  Format ID 8: 340 x 340 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 9: 352 x 288 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 10: 352 x 288 pixels  30 FPS(max)  FOURCC=420v
  Format ID 11: 424 x 240 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 12: 424 x 240 pixels  30 FPS(max)  FOURCC=420v
  Format ID 13: 440 x 440 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 14: 480 x 270 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 15: 480 x 270 pixels  30 FPS(max)  FOURCC=420v
  Format ID 16: 640 x 360 pixels  30 FPS(max)  FOURCC=420v
  Format ID 17: 640 x 480 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 18: 640 x 480 pixels  30 FPS(max)  FOURCC=420v
  Format ID 19: 640 x 480 pixels  120 FPS(max)  FOURCC=420v
  Format ID 20: 800 x 448 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 21: 800 x 448 pixels  30 FPS(max)  FOURCC=420v
  Format ID 22: 800 x 600 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 23: 800 x 600 pixels  30 FPS(max)  FOURCC=420v
  Format ID 24: 848 x 480 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 25: 848 x 480 pixels  30 FPS(max)  FOURCC=420v
  Format ID 26: 960 x 540 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 27: 960 x 540 pixels  30 FPS(max)  FOURCC=420v
  Format ID 28: 1024 x 576 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 29: 1024 x 576 pixels  30 FPS(max)  FOURCC=420v
  Format ID 30: 1280 x 720 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 31: 1280 x 720 pixels  30 FPS(max)  FOURCC=420v
  Format ID 32: 1280 x 720 pixels  90 FPS(max)  FOURCC=420v
  Format ID 33: 1600 x 896 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 34: 1600 x 896 pixels  30 FPS(max)  FOURCC=420v
  Format ID 35: 1920 x 1080 pixels  30 FPS(max)  FOURCC=yuvs
  Format ID 36: 1920 x 1080 pixels  30 FPS(max)  FOURCC=420v
  Format ID 37: 1920 x 1080 pixels  60 FPS(max)  FOURCC=420v
  Format ID 38: 2560 x 1440 pixels  30 FPS(max)  FOURCC=420v
  Format ID 39: 3840 x 2160 pixels  30 FPS(max)  FOURCC=420v
  Format ID 40: 4096 x 2160 pixels  30 FPS(max)  FOURCC=420v
[DBG ] Setup for capture format (160 x 120)...
[DBG ] UVCCtrl::findDevice() called
[VERB] USB descriptor:
[VERB]   length    = 00000009
[VERB]   type      = 00000002
[VERB]   totalLen  = 00000CC0
[VERB]   interfaces = 00000005
[VERB] Configuration
[VERB] Interface[VERB]  VIDEO/CONTROL
[VERB] Processing Unit ID: 3
[DBG ] UVCCtrl::createControlInterface: created control interface
[DBG ] Created a UVC control object!
[DBG ] FOURCC = yuvs
Stream ID = 0
Stream is open
[INFO] PlatformStream::getPropertyLimits
Exposure limits: 3 .. 2047 (default=250)
Exposure: 250
[VERB] UVCCtrl::getAutoProperty exposure
[VERB] CT_AE_MODE_CONTROL returned 00000001h
Auto exposure: 0
Captured frames: 30

[INFO] closing stream
[DBG ] Stream::~Stream reports 30 frames captured.
[DBG ] Platform context destroyed
[DBG ] m_captureDevice released
[DBG ] m_captureDevice released
[DBG ] Context destroyed

```