### PR TITLE
Some code cleanup

### DIFF
--- a/common/context.cpp
+++ b/common/context.cpp
@@ -89,7 +89,7 @@ const char* Context::getDeviceUniqueID(CapDeviceID id) const
 
 uint32_t Context::getDeviceCount() const
 {
-    return m_devices.size();
+    return static_cast<uint32_t>(m_devices.size());
 }
 
 
@@ -105,7 +105,7 @@ int32_t Context::getNumFormats(CapDeviceID index) const
         LOG(LOG_ERR,"Internal device pointer is NULL");
         return -1; // device pointer is NULL!
     }
-    return m_devices[index]->m_formats.size();
+    return static_cast<int32_t>(m_devices[index]->m_formats.size());
 }
 
 
@@ -229,7 +229,7 @@ bool Context::captureFrame(int32_t streamID, uint8_t *RGBbufferPtr, size_t RGBbu
         return false; 
     }
     
-    return m_streams[streamID]->captureFrame(RGBbufferPtr, RGBbufferBytes);
+    return m_streams[streamID]->captureFrame(RGBbufferPtr, static_cast<uint32_t>(RGBbufferBytes));
 }
 
 bool Context::hasNewFrame(int32_t streamID)

--- a/win/platformstream.h
+++ b/win/platformstream.h
@@ -133,17 +133,6 @@ public:
     /** Close a capture stream */
     virtual void close() override;
 
-    /** Returns true if a new frame is available for reading using 'captureFrame'. 
-        The internal new frame flag is reset by captureFrame.
-    */
-    bool hasNewFrame();
-
-    /** Retrieve the most recently captured frame and copy it in a
-        buffer pointed to by RGBbufferPtr. The maximum buffer size 
-        must be supplied in RGBbufferBytes.
-    */
-    bool captureFrame(uint8_t *RGBbufferPtr, uint32_t RGBbufferBytes);
-
     /** set the frame rate */
     virtual bool setFrameRate(uint32_t fps) override;
 


### PR DESCRIPTION
I've found that PlatformStream for Windows has definition of method `hasNewFrame` and `captureFrame` but has no implementation of those methods. And it seems that the presence of `hasNewFrame`/`captureFrame` in PlatformStream has not sense because those methods are not virtual. So I've removed them from Windows version of PlatformStream class.

I've also fixed code with implicit conversion from `std::size_t` to `uint32_t` and `int32_t` because such a conversion leads to warnings from VC++ compiler.