### PR TITLE
Fix / Avoid double Release() in FindCaptureDevice()

### DIFF
--- a/win/platformcontext.cpp
+++ b/win/platformcontext.cpp
@@ -453,7 +453,6 @@ HRESULT FindCaptureDevice(IBaseFilter** ppSrcFilter, const wchar_t* devicePath)
             (FAILED(hr) && strDevicePath == std::to_wstring(num_devices))) {
             VariantClear(&varName);
             hr = pMoniker->BindToObject(0, 0, IID_PPV_ARGS(ppSrcFilter));
-            pMoniker->Release();
             return hr;
         }
         VariantClear(&varName);


### PR DESCRIPTION
# Description

This fixes a semantic conflict from merging 5e8b963c271f2a700b317c63bb26c4ac57ed805a of #53 which inside `FindCaptureDevice()` was using `ScopedComPtr<>` to handle ownership of `pMoniker` _implicitly_, and 58d4be4d7db9f259cbeda0a232bd858bd690c414 of #52 which was using an explicit `Release()` on `pMoniker`. Both by @sandman42292 in time- and branch-overlapping PRs.

![Screenshot 2023-04-12 143612](https://user-images.githubusercontent.com/9963310/231463666-73fb588b-68e9-4ff3-ba72-4084261e0fd9.png)

# Justification

Crashes on Windows.

# Testing

Tested with `win/test/openpnp-capture-test.exe`. This crashed before and now works.

I was unable to test this in OpenPnP, due to lack of knowledge of how to put the dll "into" Java, in a development environment, i.e., make it override maven artifacts. 😅

Instructions welcome!
