### PR TITLE
Fix / Use CoInitializeEx(NULL, COINIT_APARTMENTTHREADED)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 
 cmake_minimum_required(VERSION 3.1)
 project (openpnp-capture)
-set(OPENPNP_CAPTURE_LIB_VERSION "0.0.26" CACHE STRING "openpnp-capture library version")
+set(OPENPNP_CAPTURE_LIB_VERSION "0.0.28" CACHE STRING "openpnp-capture library version")
 set(OPENPNP_CAPTURE_LIB_SOVERSION "0" CACHE STRING "openpnp-capture library soversion")
 
 # make sure the libjpegturbo is compiled with the

--- a/win/platformcontext.cpp
+++ b/win/platformcontext.cpp
@@ -50,7 +50,7 @@ Context* createPlatformContext()
 PlatformContext::PlatformContext() : Context()
 {
     HRESULT hr;
-    hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+    hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
     if (hr != S_OK)
     {
         // This might happen when another part of the program


### PR DESCRIPTION
# Description

On Windows Java 17 uses COM to provide Desktop functionality. Because COM has an inherently bad design, every library inside one process must conform in its use of COM. See:

https://bugs.openjdk.org/browse/JDK-8270269

Hence, in `openpnp-capture` we must equally use

```C
CoInitializeEx(NULL, COINIT_APARTMENTTHREADED)
```
I do not know if this really helps. It could be that in turn Java 11 now breaks. I have still haven't found the time to find out how to locally deploy it into OpenPnP (this PR is what I can quickly offer).

# Justification

See:
https://github.com/openpnp/openpnp/pull/1560

# Implementation Details

Tested with `win/test/openpnp-capture-test.exe`. Still works.
