### PR TITLE
Fix instances of logging not performed through the logging framework

### DIFF
--- a/common/context.cpp
+++ b/common/context.cpp
@@ -166,14 +166,7 @@ int32_t Context::openStream(CapDeviceID id, CapFormatID formatID)
     }
     else
     {
-        printf("[DBG ] FOURCC = ");
-        uint32_t fcc = s->getFOURCC();
-        for(uint32_t i=0; i<4; i++)
-        {            
-            printf("%c", (fcc & 0xff));
-            fcc >>= 8;
-        }
-        printf("\n");
+        LOG(LOG_DEBUG, "FOURCC = %s\n", fourCCToString(s->getFOURCC()).c_str());
     }
 
     int32_t streamID = storeStream(s);

--- a/mac/platformcontext.mm
+++ b/mac/platformcontext.mm
@@ -48,11 +48,11 @@ PlatformContext::PlatformContext() :
     if ([AVCaptureDevice respondsToSelector:@selector(authorizationStatusForMediaType:)]) {
         cameraPermissionReceived = 0;
         if ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo] == AVAuthorizationStatusAuthorized) {
-            NSLog(@"Already have camera permission");
+            LOG(LOG_DEBUG, "Already have camera permission\n");
             cameraPermissionReceived = 1;
         }
         else {
-            NSLog(@"Requesting permission, bundle path for Info.plist: %@", [[NSBundle mainBundle] bundlePath]);
+            LOG(LOG_INFO, "Requesting permission, bundle path for Info.plist: %s\n", [[[NSBundle mainBundle] bundlePath] UTF8String]);
             [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL granted) {
                 if (granted) {
                     cameraPermissionReceived = 1;
@@ -60,9 +60,9 @@ PlatformContext::PlatformContext() :
                     cameraPermissionReceived = -1;
                 }
                 if (granted) {
-                    NSLog(@"Permission granted");
+                    LOG(LOG_INFO, "Permission granted\n");
                 } else {
-                    NSLog(@"Failed to get permission");
+                    LOG(LOG_WARNING, "Failed to get permission\n");
                 }
             } ];
             while (cameraPermissionReceived == 0) {


### PR DESCRIPTION
As the title says, there are a few instances where the logging is not performed through the logging framework, resulting in debug level log lines that can't be turned off.