### PR TITLE
Remove manual dealloc calls on objects managed by ARC

### DIFF
--- a/mac/platformcontext.mm
+++ b/mac/platformcontext.mm
@@ -152,8 +152,6 @@ bool PlatformContext::enumerateDevices()
                 [scanner scanHexInt:&(deviceInfo->m_busLocation)];
 
                 LOG(LOG_DEBUG, "Location : %08X\n", deviceInfo->m_busLocation);
-                [scanner dealloc];
-                [hexString dealloc];
             }
             else
             {


### PR DESCRIPTION
This PR removes two manual `dealloc` calls on objects managed by ARC. In Objective C, it is a bug to manually deallocate managed objects, as ARC manages the object lifetime.

In my case, this lead to a hard crash (SIGSEGV fault) when using the library with JavaFX. Specifically, the SIGSEGV occurs in objc_msgSend (libobjc.A.dylib), with a null pointer dereference during autorelease pool cleanup (objc_autoreleasePoolPop), which occured on every window open or close operation.

 