### PR TITLE
Add support for building shared and static libraries in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,19 @@ project (openpnp-capture)
 set(OPENPNP_CAPTURE_LIB_VERSION "0.0.28" CACHE STRING "openpnp-capture library version")
 set(OPENPNP_CAPTURE_LIB_SOVERSION "0" CACHE STRING "openpnp-capture library soversion")
 
+# Library type options
+option(BUILD_SHARED_LIBS "Build shared library" ON)
+option(BUILD_STATIC_LIBS "Build static library" OFF)
+
+# Validate library type options
+if(BUILD_STATIC_LIBS AND BUILD_SHARED_LIBS)
+    message(WARNING "Both BUILD_STATIC_LIBS and BUILD_SHARED_LIBS are enabled. Building static library only.")
+    set(BUILD_SHARED_LIBS OFF)
+elseif(NOT BUILD_STATIC_LIBS AND NOT BUILD_SHARED_LIBS)
+    message(STATUS "Neither BUILD_STATIC_LIBS nor BUILD_SHARED_LIBS specified. Defaulting to shared library.")
+    set(BUILD_SHARED_LIBS ON)
+endif()
+
 # make sure the libjpegturbo is compiled with the
 # position independent flag -fPIC
 IF (UNIX)
@@ -55,10 +68,19 @@ else(CMAKE_BUILD_TYPE MATCHES Release)
 endif(CMAKE_BUILD_TYPE MATCHES Release)
 
 # create our capture library
-add_library(openpnp-capture SHARED common/libmain.cpp
-                                   common/context.cpp
-                                   common/logging.cpp
-                                   common/stream.cpp)
+if(BUILD_STATIC_LIBS AND NOT BUILD_SHARED_LIBS)
+    set(LIBRARY_TYPE STATIC)
+    add_definitions(-DOPENPNPCAPTURE_STATIC)
+    message(STATUS "Building static library")
+else()
+    set(LIBRARY_TYPE SHARED)
+    message(STATUS "Building shared library")
+endif()
+
+add_library(openpnp-capture ${LIBRARY_TYPE} common/libmain.cpp
+                                           common/context.cpp
+                                           common/logging.cpp
+                                           common/stream.cpp)
 
 target_include_directories(openpnp-capture PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/README_BUILD.md
+++ b/README_BUILD.md
@@ -1,0 +1,74 @@
+# Building OpenPnP Capture Library
+
+## Windows Build Options
+
+The bootstrap.bat script now provides multiple build options for Windows:
+
+### Using bootstrap.bat
+
+Run `bootstrap.bat` and choose from the following options:
+
+1. **Visual Studio with NMake (Shared Library - Release)** - Default shared library build
+2. **Visual Studio with Ninja Build (Shared Library - Release)** - Shared library with Ninja
+3. **Visual Studio with NMake (Static Library - Release)** - Static library, Release mode
+4. **Visual Studio with NMake (Static Library - Debug)** - Static library, Debug mode  
+5. **Visual Studio with Ninja Build (Static Library - Release)** - Static library with Ninja, Release
+6. **Visual Studio with Ninja Build (Static Library - Debug)** - Static library with Ninja, Debug
+7. **Exit**
+
+### Manual CMake Configuration
+
+You can also configure the build manually using CMake options:
+
+#### For Shared Library (default):
+```bash
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -G "NMake Makefiles" ..
+```
+
+#### For Static Library:
+```bash
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON -G "NMake Makefiles" ..
+```
+
+#### For Debug Static Library:
+```bash
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON -G "NMake Makefiles" ..
+```
+
+## CMake Options
+
+- `BUILD_SHARED_LIBS`: Build shared library (default: ON)
+- `BUILD_STATIC_LIBS`: Build static library (default: OFF)
+
+**Note**: If both options are enabled, the build will default to static library with a warning.
+
+## Usage in Your Project
+
+### When Using Static Library
+
+When linking against the static library, make sure to define `OPENPNPCAPTURE_STATIC` in your project to ensure correct symbol linkage:
+
+```cpp
+#define OPENPNPCAPTURE_STATIC
+#include "openpnp-capture.h"
+```
+
+Or add it as a compile definition in your CMakeLists.txt:
+
+```cmake
+target_compile_definitions(your_target PRIVATE OPENPNPCAPTURE_STATIC)
+```
+
+### When Using Shared Library
+
+No special definitions are needed for shared library usage:
+
+```cpp
+#include "openpnp-capture.h"
+```

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -1,13 +1,21 @@
 @ECHO OFF
 ECHO Please choose build system:
-ECHO 1. Visual Studio with NMake
-ECHO 2. Visual Studio with Ninja Build
-ECHO 3. Exit
+ECHO 1. Visual Studio with NMake (Shared Library - Release)
+ECHO 2. Visual Studio with Ninja Build (Shared Library - Release)
+ECHO 3. Visual Studio with NMake (Static Library - Release)
+ECHO 4. Visual Studio with NMake (Static Library - Debug)
+ECHO 5. Visual Studio with Ninja Build (Static Library - Release)
+ECHO 6. Visual Studio with Ninja Build (Static Library - Debug)
+ECHO 7. Exit
 ECHO .
 
-CHOICE /C 123 /M "Enter your choice:"
+CHOICE /C 1234567 /M "Enter your choice:"
 
-IF ERRORLEVEL 3 GOTO End
+IF ERRORLEVEL 7 GOTO End
+IF ERRORLEVEL 6 GOTO NinjaStaticDebug
+IF ERRORLEVEL 5 GOTO NinjaStaticRelease
+IF ERRORLEVEL 4 GOTO VSStaticDebug
+IF ERRORLEVEL 3 GOTO VSStaticRelease
 IF ERRORLEVEL 2 GOTO NinjaBuild
 IF ERRORLEVEL 1 GOTO VS
 
@@ -23,6 +31,34 @@ mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release -G "Ninja" ..
 cd .. 
+GOTO End
+
+:VSStaticRelease
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON -G "NMake Makefiles" ..
+cd ..
+GOTO End
+
+:VSStaticDebug
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON -G "NMake Makefiles" ..
+cd ..
+GOTO End
+
+:NinjaStaticRelease
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON -G "Ninja" ..
+cd ..
+GOTO End
+
+:NinjaStaticDebug
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON -G "Ninja" ..
+cd ..
 GOTO End
 
 :End

--- a/include/openpnp-capture.h
+++ b/include/openpnp-capture.h
@@ -42,8 +42,13 @@
     #define SO_IMPORT
     #define SO_EXPORT
 #elif defined(_MSC_VER)
-    #define SO_IMPORT __declspec(dllimport)
-    #define SO_EXPORT __declspec(dllexport)
+    #ifndef OPENPNPCAPTURE_STATIC
+        #define SO_IMPORT __declspec(dllimport)
+        #define SO_EXPORT __declspec(dllexport)
+    #else
+        #define SO_IMPORT
+        #define SO_EXPORT
+    #endif
 #else
     #error("Unknown compiler")
 #endif


### PR DESCRIPTION
Tested on Windows with Visual Studio 2022 Community Edition

> I am unfamiliar with contribution guidelines, so apologies if there is more missing while proposing this change.

- Introduced options to build shared and static libraries.
- Updated CMakeLists.txt to validate library type options.
- Enhanced bootstrap.bat to include static library build options.
- Added detailed build instructions to README_BUILD.md.
- Modified openpnp-capture.h to handle symbol export for static libraries.