### PR TITLE
Explicitly set `libjpeg-turbo` install libdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ ELSEIF(UNIX)
             SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/linux/contrib/libjpeg-turbo-3.1.2
             CMAKE_ARGS
                 -DCMAKE_INSTALL_PREFIX=${LIBJPEG_TURBO_INSTALL_DIR}
+                -DCMAKE_INSTALL_LIBDIR=lib
                 -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                 -DENABLE_SHARED=OFF
                 -DWITH_SIMD=ON


### PR DESCRIPTION
If not explicitly set, the directory name changes based on the system (lib, lib64, libx32, lib32), resulting in cmake failing to find the imported static lib